### PR TITLE
Operator: Documentation and ProviderConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,39 @@
 # provider-in-cluster
 
-### Note this Provider in early alpha, breaking changes may occur!
+## Note this Provider in early alpha, breaking changes may occur!
+
+The Provider-In-Cluster is designed to provision and configure resources in an arbitrary Kubernetes cluster. These resources run inside of the cluster, and are also managed by the cluster.
 
 ## How to Run
 
 ### Prerequisites
+
 1. Crossplane Operator - instructions to install this operator can be found on the [Crossplane Docs](https://crossplane.io/docs/v0.14/getting-started/install-configure.html)
 2. Crossplane CLI - the [Crossplane CLI](https://crossplane.io/docs/v0.14/getting-started/install-configure.html#install-crossplane-cli) will make installing providers very simple
 3. Kubernetes Cluster - You will need a Kubernetes cluster :)
 
-### Installing
+## Installing
 
 You can install the most recent version of this Provider by running the following command:
 `kubectl crossplane install provider crossplane/provider-in-cluster:master`
 
 After installing, you will need a ProviderConfig to provide appropriate credentials for the operator. An example of how to achieve this can be found in the [examples directory](examples/).
 
-## OLM
+## Getting Started
 
-We currently support a resource to wrap arbitrary OLM packages. 
+There are examples of the supported resources under the [examples](examples/) folder. This includes the providerConfig, postgres and operator resources
 
-### Vanilla Kubernetes
+### OLM
 
-For a fresh Kubernetes cluster (e.g., `kind`), you can install the OLM by running the following command: `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/install.sh | bash -s v0.17.0`
+Under the OLM package we support the creation of arbitrary operator SDK operators. This uses the existing subscription mechanism in the OLM (Operator Lifecycle Manager).
 
-You can see available operators by running the following command: `kubectl get packagemanifests -n olm`. 
+More detailed documentation can be found in the [OLM docs](docs/olm.md).
 
-Prior to creating a subscription, you will need to create an operator-group, there are plans to include this lifecycle for Operator resources in the future.
+### Database
 
-### Openshift
+Under the database package we currently support provisoning instances of Postgres.
 
-For an Openshift cluster, the OLM will be installed already, and you can see available operators by running the following command: `kubectl get packagemanifests -n openshift-marketplace`. 
-
-
-### Example
-
-For using the Operator resource, you can see an example under the [examples/operator](examples/operator) directory.
-
-## Database
-
-We currently have support for Postgres in-cluster, this uses a PVC with a provided storage class. 
+More documentation on this can be found in the [database docs](docs/database.md).
 
 ## Planned support
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ The Provider-In-Cluster is designed to provision and configure resources in an a
 ## Installing
 
 You can install the most recent version of this Provider by running the following command:
-`kubectl crossplane install provider crossplane/provider-in-cluster:master`
+```bash
+kubectl crossplane install provider crossplane/provider-in-cluster:master
+```
 
 After installing, you will need a ProviderConfig to provide appropriate credentials for the operator. An example of how to achieve this can be found in the [examples directory](examples/).
 
 ## Getting Started
 
-There are examples of the supported resources under the [examples](examples/) folder. This includes the providerConfig, postgres and operator resources
+There are examples of the supported resources under the [examples](examples/) folder. This includes the providerConfig, postgres and operator resources.
+
+To run the provider-in-cluster, you first need to set up the ProviderConfig, which expects a secret which contains a valid Kubeconfig to access the cluster. 
+There is a [utility script](examples/kubeconfig.sh) to create the secret which expects a path to a Kubeconfig. After, you can create the 
+[provider-config](examples/provider-config.yaml). Now, you should be able to create any of the other resources made available by the provider-in-cluster.
 
 ### OLM
 
@@ -31,7 +37,7 @@ More detailed documentation can be found in the [OLM docs](docs/olm.md).
 
 ### Database
 
-Under the database package we currently support provisoning instances of Postgres.
+Under the database package we currently support provisioning instances of Postgres.
 
 More documentation on this can be found in the [database docs](docs/database.md).
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # provider-in-cluster
+
+### Note this Provider in early alpha, breaking changes may occur!
+
+## How to Run
+
+### Prerequisites
+1. Crossplane Operator - instructions to install this operator can be found on the [Crossplane Docs](https://crossplane.io/docs/v0.14/getting-started/install-configure.html)
+2. Crossplane CLI - the [Crossplane CLI](https://crossplane.io/docs/v0.14/getting-started/install-configure.html#install-crossplane-cli) will make installing providers very simple
+3. Kubernetes Cluster - You will need a Kubernetes cluster :)
+
+### Installing
+
+You can install the most recent version of this Provider by running the following command:
+`kubectl crossplane install provider crossplane/provider-in-cluster:master`
+
+After installing, you will need a ProviderConfig to provide appropriate credentials for the operator. An example of how to achieve this can be found in the [examples directory](examples/).
+
+## OLM
+
+We currently support a resource to wrap arbitrary OLM packages. 
+
+### Vanilla Kubernetes
+
+For a fresh Kubernetes cluster (e.g., `kind`), you can install the OLM by running the following command: `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/install.sh | bash -s v0.17.0`
+
+You can see available operators by running the following command: `kubectl get packagemanifests -n olm`. 
+
+Prior to creating a subscription, you will need to create an operator-group, there are plans to include this lifecycle for Operator resources in the future.
+
+### Openshift
+
+For an Openshift cluster, the OLM will be installed already, and you can see available operators by running the following command: `kubectl get packagemanifests -n openshift-marketplace`. 
+
+
+### Example
+
+For using the Operator resource, you can see an example under the [examples/operator](examples/operator) directory.
+
+## Database
+
+We currently have support for Postgres in-cluster, this uses a PVC with a provided storage class. 
+
+## Planned support
+
+- Redis in cluster
+- Object storage

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,11 @@
+# Database
+
+Currently under the database API group we only support provisioning instances PostgreSQL, but there are concrete plans to add support for other database applications. Note, in-cluster provisioning is also possible using the [Provider-Rook](https://github.com/crossplane/provider-rook), which support the Database services exposed by Rook.
+
+## Example
+
+Under the [examples/](../examples/database/) there is an example manifest for the postgres resource. This resource accepts a reference to a secret containing the password under the path `spec.forProvider.masterPasswordSecretRef`. The password secret is optional, if one is not provided, a password will be generated.
+
+For storage, the resource accepts a StorageClass which will be used to access a PVC, if a valid PVC does not exist or cannot be provisioned, the creation of the Database instance will block.
+
+When the resource is finished being provisioned, an output secret with the password, endpoint, database, port and username will be created.

--- a/docs/olm.md
+++ b/docs/olm.md
@@ -1,0 +1,26 @@
+# OLM
+
+We currently support a resource which wraps arbitrary OLM packages.
+
+## Vanilla Kubernetes
+
+For a fresh Kubernetes cluster (e.g., `kind`), you can install the OLM by running the following command: `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/install.sh | bash -s v0.17.0`
+
+You can see installable operators by running the following command: `kubectl get packagemanifests -n olm`, which displays all the available packagemanifests, each of which can correspond to one or more subscription.
+
+Prior to creating a though subscription, you will need to create an operator-group, there are plans to include this automatic reconsilation for operator groups in the lifecycle for Operator resources in the future.
+
+## Openshift
+
+For an Openshift cluster, the OLM will be installed already, and you can see available operators by running the following command: `kubectl get packagemanifests -n openshift-marketplace`. By default there should be a valid operator group in the default namespace.
+
+## Example
+
+To use the the Operator resource, you need to configure a few key fields, namely:
+
+- `operatorName`: Which is the internal name of the operator, note that this can differ from the name exposed by the call to list all packagemanifests.
+- `catalogSource`: The specific catalog resource is operator is exposed by
+- `catalogSourceNamespace`: The namespace in which that catalog resource resides
+- `channel`: The channel that should be created, typically you will want to use the stable channel, however some operators exposes different versions (e.g., main, alpha, etc.)
+
+Examples of the operator resource can found under the [examples/operator](../examples/operator) directory.

--- a/docs/olm.md
+++ b/docs/olm.md
@@ -4,23 +4,34 @@ We currently support a resource which wraps arbitrary OLM packages.
 
 ## Vanilla Kubernetes
 
-For a fresh Kubernetes cluster (e.g., `kind`), you can install the OLM by running the following command: `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/install.sh | bash -s v0.17.0`
+For a fresh Kubernetes cluster (e.g., `kind`), you can install the OLM by running the following command: 
+```bash
+curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/install.sh | bash -s v0.17.0
+```
 
-You can see installable operators by running the following command: `kubectl get packagemanifests -n olm`, which displays all the available packagemanifests, each of which can correspond to one or more subscription.
+You can see installable operators by running the following command: 
+```bash
+kubectl get packagemanifests -n olm
+```
+Which displays all the available packagemanifests, each of which can correspond to one or more subscription.
 
 Prior to creating a though subscription, you will need to create an operator-group, there are plans to include this automatic reconsilation for operator groups in the lifecycle for Operator resources in the future.
 
 ## Openshift
 
-For an Openshift cluster, the OLM will be installed already, and you can see available operators by running the following command: `kubectl get packagemanifests -n openshift-marketplace`. By default there should be a valid operator group in the default namespace.
+For an Openshift cluster, the OLM will be installed already, and you can see available operators by running the following command: 
+```bash
+kubectl get packagemanifests -n openshift-marketplace
+```
+By default, there should be a valid operator group in the default namespace.
 
 ## Example
 
-To use the the Operator resource, you need to configure a few key fields, namely:
+To use the Operator resource, you need to configure a few key fields, namely:
 
-- `operatorName`: Which is the internal name of the operator, note that this can differ from the name exposed by the call to list all packagemanifests.
-- `catalogSource`: The specific catalog resource is operator is exposed by
-- `catalogSourceNamespace`: The namespace in which that catalog resource resides
-- `channel`: The channel that should be created, typically you will want to use the stable channel, however some operators exposes different versions (e.g., main, alpha, etc.)
+- `operatorName` - Which is the internal name of the operator, note that this can differ from the name exposed by the call to list all packagemanifests.
+- `catalogSource` - The specific catalog resource that exposes the operator 
+- `catalogSourceNamespace` - The namespace in which that catalog resource resides
+- `channel` - The channel that should be created, typically you will want to use the stable channel, however some operators exposes different versions (e.g., main, alpha, etc.)
 
 Examples of the operator resource can found under the [examples/operator](../examples/operator) directory.

--- a/examples/kubeconfig.sh
+++ b/examples/kubeconfig.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+oc create secret generic cluster-config --from-file=kubeconfig="$1"

--- a/examples/operator/subscription.yaml
+++ b/examples/operator/subscription.yaml
@@ -4,8 +4,10 @@ metadata:
   name: my-project-quay
   namespace: default
 spec:
+  providerConfigRef:
+    name: provider-in-cluster
   forProvider:
     channel: stable
     operatorName: rh-quay-operator
     catalogSource: krishchow-catalog-source
-    catalogSourceNamespace: olm
+    catalogSourceNamespace: openshift-marketplace

--- a/examples/provider-config.yaml
+++ b/examples/provider-config.yaml
@@ -4,4 +4,8 @@ metadata:
   name: provider-in-cluster
 spec:
   credentials:
-    source: None
+    source: Secret
+    secretRef:
+      name: cluster-config
+      key: kubeconfig
+      namespace: default

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane-contrib/provider-in-cluster/apis/v1beta1"
+)
+
+const (
+	errFailedToGetSecret                 = "failed to get secret from namespace \"%s\""
+	errSecretDataIsNil                   = "secret data is nil"
+	errProviderConfigNotSet              = "provider config is not set"
+	errProviderNotRetrieved              = "provider could not be retrieved"
+	errCredSecretNotSet                  = "provider credentials secret is not set"
+	errProviderSecretNotRetrieved        = "secret referred in provider could not be retrieved"
+	errFailedToCreateRestConfig          = "cannot create new rest config using provider secret"
+	errProviderSecretValueForKeyNotFound = "value for key \"%s\" not found in provider credentials secret"
+	errFmtUnsupportedCredSource          = "unsupported credentials source %q"
+)
+
+// NewRestConfig returns a rest config given a secret with connection information.
+func NewRestConfig(kubeconfig []byte) (*rest.Config, error) {
+	ac, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load kubeconfig")
+	}
+	return restConfigFromAPIConfig(ac)
+}
+
+// NewKubeClient returns a kubernetes client given a secret with connection
+// information.
+func NewKubeClient(config *rest.Config) (client.Client, error) {
+	kc, err := client.New(config, client.Options{})
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create Kubernetes client")
+	}
+
+	return kc, nil
+}
+
+func restConfigFromAPIConfig(c *api.Config) (*rest.Config, error) {
+	if c.CurrentContext == "" {
+		return nil, errors.New("currentContext not set in kubeconfig")
+	}
+	ctx := c.Contexts[c.CurrentContext]
+	cluster := c.Clusters[ctx.Cluster]
+	if cluster == nil {
+		return nil, errors.New(fmt.Sprintf("cluster for currentContext (%s) not found", c.CurrentContext))
+	}
+	user := c.AuthInfos[ctx.AuthInfo]
+	if user == nil {
+		return nil, errors.New(fmt.Sprintf("auth info for currentContext (%s) not found", c.CurrentContext))
+	}
+	return &rest.Config{
+		Host:            cluster.Server,
+		Username:        user.Username,
+		Password:        user.Password,
+		BearerToken:     user.Token,
+		BearerTokenFile: user.TokenFile,
+		Impersonate: rest.ImpersonationConfig{
+			UserName: user.Impersonate,
+			Groups:   user.ImpersonateGroups,
+			Extra:    user.ImpersonateUserExtra,
+		},
+		AuthProvider: user.AuthProvider,
+		ExecProvider: user.Exec,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure:   cluster.InsecureSkipTLSVerify,
+			ServerName: cluster.TLSServerName,
+			CertData:   user.ClientCertificateData,
+			KeyData:    user.ClientKeyData,
+			CAData:     cluster.CertificateAuthorityData,
+		},
+	}, nil
+}
+
+// GetSecretData extracts arbitrary data from a Kubernetes secret
+func GetSecretData(ctx context.Context, kube client.Client, nn types.NamespacedName) (map[string][]byte, error) {
+	s := &corev1.Secret{}
+	if err := kube.Get(ctx, nn, s); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf(errFailedToGetSecret, nn.Namespace))
+	}
+	if s.Data == nil {
+		return nil, errors.New(errSecretDataIsNil)
+	}
+	return s.Data, nil
+}
+
+// GetProviderConfigRC gets the provider config secret, and parses it into a rest.Config
+func GetProviderConfigRC(ctx context.Context, cr resource.Managed, kube client.Client) (*rest.Config, error) { //nolint:gocyclo
+	p := &v1beta1.ProviderConfig{}
+
+	if cr.GetProviderConfigReference() == nil {
+		return nil, errors.New(errProviderConfigNotSet)
+	}
+
+	n := types.NamespacedName{Name: cr.GetProviderConfigReference().Name}
+	if err := kube.Get(ctx, n, p); err != nil {
+		return nil, errors.Wrap(err, errProviderNotRetrieved)
+	}
+
+	s := p.Spec.Credentials.Source
+	switch s { //nolint:exhaustive
+	case runtimev1alpha1.CredentialsSourceInjectedIdentity:
+		rc, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, errors.Wrap(err, errFailedToCreateRestConfig)
+		}
+		return rc, nil
+	case runtimev1alpha1.CredentialsSourceSecret:
+		ref := p.Spec.Credentials.SecretRef
+		if ref == nil {
+			return nil, errors.New(errCredSecretNotSet)
+		}
+
+		key := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
+		d, err := GetSecretData(ctx, kube, key)
+		if err != nil {
+			return nil, errors.Wrap(err, errProviderSecretNotRetrieved)
+		}
+		kc, f := d[ref.Key]
+		if !f {
+			return nil, errors.Errorf(errProviderSecretValueForKeyNotFound, ref.Key)
+		}
+		rc, err := NewRestConfig(kc)
+		if err != nil {
+			return nil, errors.Wrap(err, errFailedToCreateRestConfig)
+		}
+		return rc, nil
+	default:
+		return nil, errors.Errorf(errFmtUnsupportedCredSource, s)
+	}
+}


### PR DESCRIPTION
This PR adds support for a provided kubeconfig via a secret for the operator and Postgres resources. Additionally, this adds some initial documentation for how to run the operator and future plans.